### PR TITLE
Fix NPE when there are no database

### DIFF
--- a/debug-db/src/main/java/com/amitshekhar/server/ClientServer.java
+++ b/debug-db/src/main/java/com/amitshekhar/server/ClientServer.java
@@ -407,7 +407,7 @@ public class ClientServer implements Runnable {
 
     public Response getDBList() {
         Response response = new Response();
-        if (mDatabaseDir != null) {
+        if (mDatabaseDir != null && mDatabaseDir.list() != null) {
             for (String name : mDatabaseDir.list()) {
                 response.rows.add(name);
             }


### PR DESCRIPTION
When the app has no database I get this NPE

`java.lang.NullPointerException: Attempt to get length of null array
    at com.amitshekhar.server.ClientServer.getDBList(ClientServer.java:411)
    at com.amitshekhar.server.ClientServer.handle(ClientServer.java:214)
    at com.amitshekhar.server.ClientServer.run(ClientServer.java:126)
    at java.lang.Thread.run(Thread.java:818)`

Null check on mDatabaseDir.list() fixes this