### PR TITLE
list table name in non case sensitive alphabetical order

### DIFF
--- a/debug-db/src/main/assets/app.js
+++ b/debug-db/src/main/assets/app.js
@@ -81,6 +81,7 @@ function getDBList() {
 
 }
 
+var lastTableName = getHashValue('table');
 function openDatabaseAndGetTableList(db) {
 
     if("APP_SHARED_PREFERENCES" == db) {
@@ -110,10 +111,14 @@ function openDatabaseAndGetTableList(db) {
            }
            $('#table-list').empty()
            for(var count = 0; count < tableList.length; count++){
-             var tableName = tableList[count];
-             $("#table-list").append("<a href='#' data-db-name='"+db+"' data-table-name='"+tableName+"' class='list-group-item' onClick='getData(\""+ tableName + "\");'>" +tableName + "</a>");
-           }
+                var tableName = tableList[count];
+				$("#table-list").append("<a href='#table=" + tableName + "' data-db-name='" + db + "' data-table-name='" + tableName
+					+ "' class='list-group-item' onClick='getData(\"" + tableName + "\");'>" + tableName + "</a>");
+			}
 
+			if (lastTableName !== null) {
+				$('a[data-table-name=' + lastTableName + ']').trigger('click');
+			}
    }});
 
 }
@@ -388,4 +393,9 @@ function showErrorInfo(message){
     setTimeout(function(){
         snackbarElement.removeClass("show");
     }, 3000);
+}
+
+function getHashValue(key) {
+	var matches = location.hash.match(new RegExp(key + '=([^&]*)'));
+	return matches ? matches[1] : null;
 }

--- a/debug-db/src/main/java/com/amitshekhar/utils/DatabaseHelper.java
+++ b/debug-db/src/main/java/com/amitshekhar/utils/DatabaseHelper.java
@@ -46,7 +46,7 @@ public class DatabaseHelper {
 
     public static Response getAllTableName(SQLiteDatabase database) {
         Response response = new Response();
-        Cursor c = database.rawQuery("SELECT name FROM sqlite_master WHERE type='table' OR type='view'", null);
+        Cursor c = database.rawQuery("SELECT name FROM sqlite_master WHERE type='table' OR type='view' ORDER BY name", null);
         if (c.moveToFirst()) {
             while (!c.isAfterLast()) {
                 response.rows.add(c.getString(0));

--- a/debug-db/src/main/java/com/amitshekhar/utils/DatabaseHelper.java
+++ b/debug-db/src/main/java/com/amitshekhar/utils/DatabaseHelper.java
@@ -46,7 +46,7 @@ public class DatabaseHelper {
 
     public static Response getAllTableName(SQLiteDatabase database) {
         Response response = new Response();
-        Cursor c = database.rawQuery("SELECT name FROM sqlite_master WHERE type='table' OR type='view' ORDER BY name", null);
+        Cursor c = database.rawQuery("SELECT name FROM sqlite_master WHERE type='table' OR type='view' ORDER BY name COLLATE NOCASE", null);
         if (c.moveToFirst()) {
             while (!c.isAfterLast()) {
                 response.rows.add(c.getString(0));


### PR DESCRIPTION
When create many tables successively, table name should list in alphabetical order, like most database tools do, eg: DbVisualizer. 
Otherwise, the disorder(the table create order) list make people really crazy when they wanna find some tables, it looks weird and dizzy.