### PR TITLE
Fix issue #151: Incorrectly convert SQL statement for quoted table name.

### DIFF
--- a/debug-db-base/src/main/java/com/amitshekhar/utils/DatabaseHelper.java
+++ b/debug-db-base/src/main/java/com/amitshekhar/utils/DatabaseHelper.java
@@ -95,7 +95,8 @@ public class DatabaseHelper {
 
 
         if (!TextUtils.isEmpty(tableName)) {
-            selectQuery = selectQuery.replace(tableName, quotedTableName);
+            selectQuery = selectQuery.replaceFirst("(?i)from\\s+" + tableName + "\\s+",
+                "from " + quotedTableName + " ");
         }
 
         try {
@@ -390,7 +391,10 @@ public class DatabaseHelper {
 
             if (!TextUtils.isEmpty(tableName)) {
                 String quotedTableName = getQuotedTableName(tableName);
-                sql = sql.replace(tableName, quotedTableName);
+                sql = sql.replaceFirst("(?i)from\\s+" + tableName + "\\s+",
+                    "from " + quotedTableName + " ");
+                sql = sql.replaceFirst("(?i)^\\s*update\\s+" + tableName + "\\s+",
+                    "update " + quotedTableName + " ");
             }
 
             database.execSQL(sql);


### PR DESCRIPTION
Fix issue #151: Incorrectly convert SQL statement for quoted table name.

It incorrectly converts statement like:
select * from plu where pluNo='1000035'
to
select * from [plu] where [plu]No='1000035'