### PR TITLE
Handle db password config which db name contains hyphen

### DIFF
--- a/debug-db-base/src/main/java/com/amitshekhar/utils/DatabaseFileProvider.java
+++ b/debug-db-base/src/main/java/com/amitshekhar/utils/DatabaseFileProvider.java
@@ -56,7 +56,8 @@ public class DatabaseFileProvider {
         if (nameWithoutExt.endsWith(".db")) {
             nameWithoutExt = nameWithoutExt.substring(0, nameWithoutExt.lastIndexOf('.'));
         }
-        String resourceName = MessageFormat.format(DB_PASSWORD_RESOURCE, nameWithoutExt.toUpperCase());
+        String resourceName = MessageFormat.format(DB_PASSWORD_RESOURCE, nameWithoutExt.toUpperCase())
+                .replace('-', '_');
         String password = "";
 
         int resourceId = context.getResources().getIdentifier(resourceName, "string", context.getPackageName());


### PR DESCRIPTION
Currently, this library does not handle to set up a DB password in which the DB name contains the hyphen character.

Given a DB name `some-app.db`, to set up the DB password in gradle we can do a following step

```gradle
resValue "string", "DB_PASSWORD_SOME_APP", "somepassword"
```