### PR TITLE
Upgrade to support AndroidX libraries

### DIFF
--- a/debug-db-base/build.gradle
+++ b/debug-db-base/build.gradle
@@ -26,7 +26,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         resValue("string", "PORT_NUMBER", "8080")
     }
     buildTypes {
@@ -35,14 +35,18 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
 }
 
 dependencies {
     implementation 'com.google.code.gson:gson:2.8.5'
-    implementation 'android.arch.persistence.room:runtime:1.1.1'
+    implementation 'androidx.room:room-runtime:2.4.2'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }
 
 //apply from: 'debug-db-base-upload.gradle'

--- a/debug-db-base/src/androidTest/java/com/amitshekhar/ExampleInstrumentedTest.java
+++ b/debug-db-base/src/androidTest/java/com/amitshekhar/ExampleInstrumentedTest.java
@@ -20,8 +20,8 @@
 package com.amitshekhar;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,7 +38,7 @@ public class ExampleInstrumentedTest {
     @Test
     public void useAppContext() throws Exception {
         // Context of the app under test.
-        Context appContext = InstrumentationRegistry.getTargetContext();
+        Context appContext = InstrumentationRegistry.getInstrumentation().getContext();
 
         assertEquals("com.amitshekhar.test", appContext.getPackageName());
     }

--- a/debug-db-base/src/main/java/com/amitshekhar/DebugDB.java
+++ b/debug-db-base/src/main/java/com/amitshekhar/DebugDB.java
@@ -19,7 +19,7 @@
 
 package com.amitshekhar;
 
-import android.arch.persistence.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.SupportSQLiteDatabase;
 import android.content.Context;
 import android.util.Log;
 import android.util.Pair;

--- a/debug-db-base/src/main/java/com/amitshekhar/server/ClientServer.java
+++ b/debug-db-base/src/main/java/com/amitshekhar/server/ClientServer.java
@@ -23,7 +23,7 @@ package com.amitshekhar.server;
  * Created by amitshekhar on 15/11/16.
  */
 
-import android.arch.persistence.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.SupportSQLiteDatabase;
 import android.content.Context;
 import android.util.Log;
 import android.util.Pair;

--- a/debug-db-base/src/main/java/com/amitshekhar/server/RequestHandler.java
+++ b/debug-db-base/src/main/java/com/amitshekhar/server/RequestHandler.java
@@ -19,7 +19,7 @@
 
 package com.amitshekhar.server;
 
-import android.arch.persistence.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.SupportSQLiteDatabase;
 import android.content.Context;
 import android.content.res.AssetManager;
 import android.net.Uri;

--- a/debug-db-base/src/main/java/com/amitshekhar/sqlite/InMemoryDebugSQLiteDB.java
+++ b/debug-db-base/src/main/java/com/amitshekhar/sqlite/InMemoryDebugSQLiteDB.java
@@ -1,6 +1,6 @@
 package com.amitshekhar.sqlite;
 
-import android.arch.persistence.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.SupportSQLiteDatabase;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.SQLException;

--- a/debug-db-encrypt/build.gradle
+++ b/debug-db-encrypt/build.gradle
@@ -7,7 +7,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {
@@ -15,14 +15,18 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
 }
 
 dependencies {
     api project(':debug-db-base')
     implementation 'net.zetetic:android-database-sqlcipher:3.5.9'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }
 
 //apply from: 'debug-db-encrypt-upload.gradle'

--- a/debug-db-encrypt/src/androidTest/java/com/amitshekhar/debug/encrypt/ExampleInstrumentedTest.java
+++ b/debug-db-encrypt/src/androidTest/java/com/amitshekhar/debug/encrypt/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package com.amitshekhar.debug.encrypt;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/debug-db/build.gradle
+++ b/debug-db/build.gradle
@@ -7,7 +7,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {
@@ -15,13 +15,17 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
 }
 
 dependencies {
     api project(':debug-db-base')
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }
 
 //apply from: 'debug-db-upload.gradle'

--- a/debug-db/src/androidTest/java/com/amitshekhar/debug/ExampleInstrumentedTest.java
+++ b/debug-db/src/androidTest/java/com/amitshekhar/debug/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package com.amitshekhar.debug;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,7 +19,7 @@ public class ExampleInstrumentedTest {
     @Test
     public void useAppContext() {
         // Context of the app under test.
-        Context appContext = InstrumentationRegistry.getTargetContext();
+        Context appContext = InstrumentationRegistry.getInstrumentation().getContext();
 
         assertEquals("com.amitshekhar.debug.test", appContext.getPackageName());
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,6 +28,8 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.

--- a/sample-app-encrypt/build.gradle
+++ b/sample-app-encrypt/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
     defaultConfig {
         applicationId "com.sample.encrypt"
         minSdkVersion 15
-        targetSdkVersion 28
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
     }
     buildTypes {
@@ -21,15 +21,19 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
 }
 
 dependencies {
     debugImplementation project(':debug-db-encrypt')
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'net.zetetic:android-database-sqlcipher:3.5.9'
-    implementation 'android.arch.persistence.room:runtime:1.1.1'
-    annotationProcessor 'android.arch.persistence.room:compiler:1.1.1'
+    implementation 'androidx.room:room-runtime:2.4.2'
+    annotationProcessor 'androidx.room:room-compiler:2.4.2'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/sample-app-encrypt/src/androidTest/java/com/sample/encrypt/ExampleInstrumentedTest.java
+++ b/sample-app-encrypt/src/androidTest/java/com/sample/encrypt/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package com.sample.encrypt;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/sample-app-encrypt/src/main/AndroidManifest.xml
+++ b/sample-app-encrypt/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/sample-app-encrypt/src/main/java/com/sample/encrypt/MainActivity.java
+++ b/sample-app-encrypt/src/main/java/com/sample/encrypt/MainActivity.java
@@ -24,7 +24,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.view.View;
 
 import com.sample.encrypt.database.CarDBHelper;

--- a/sample-app-encrypt/src/main/java/com/sample/encrypt/database/room/AppDatabase.java
+++ b/sample-app-encrypt/src/main/java/com/sample/encrypt/database/room/AppDatabase.java
@@ -1,7 +1,7 @@
 package com.sample.encrypt.database.room;
 
-import android.arch.persistence.room.Database;
-import android.arch.persistence.room.RoomDatabase;
+import androidx.room.Database;
+import androidx.room.RoomDatabase;
 
 /**
  * Created by anandgaurav on 12/02/18.

--- a/sample-app-encrypt/src/main/java/com/sample/encrypt/database/room/User.java
+++ b/sample-app-encrypt/src/main/java/com/sample/encrypt/database/room/User.java
@@ -1,7 +1,7 @@
 package com.sample.encrypt.database.room;
 
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.PrimaryKey;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
 
 /**
  * Created by anandgaurav on 12/02/18.

--- a/sample-app-encrypt/src/main/java/com/sample/encrypt/database/room/UserDBHelper.java
+++ b/sample-app-encrypt/src/main/java/com/sample/encrypt/database/room/UserDBHelper.java
@@ -1,7 +1,7 @@
 package com.sample.encrypt.database.room;
 
-import android.arch.persistence.db.SupportSQLiteDatabase;
-import android.arch.persistence.room.Room;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.room.Room;
 import android.content.Context;
 
 import java.util.List;

--- a/sample-app-encrypt/src/main/java/com/sample/encrypt/database/room/UserDao.java
+++ b/sample-app-encrypt/src/main/java/com/sample/encrypt/database/room/UserDao.java
@@ -1,10 +1,10 @@
 package com.sample.encrypt.database.room;
 
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Delete;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.OnConflictStrategy;
-import android.arch.persistence.room.Query;
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
 
 import java.util.List;
 

--- a/sample-app-encrypt/src/main/java/com/sample/encrypt/utils/Utils.java
+++ b/sample-app-encrypt/src/main/java/com/sample/encrypt/utils/Utils.java
@@ -19,7 +19,7 @@
 
 package com.sample.encrypt.utils;
 
-import android.arch.persistence.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.SupportSQLiteDatabase;
 import android.content.Context;
 import android.util.Pair;
 import android.widget.Toast;

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -20,14 +20,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
     defaultConfig {
         applicationId "com.sample"
         minSdkVersion 15
-        targetSdkVersion 28
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         debug {
@@ -38,14 +38,18 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
 }
 
 dependencies {
     debugImplementation project(':debug-db')
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'android.arch.persistence.room:runtime:1.1.1'
-    annotationProcessor 'android.arch.persistence.room:compiler:1.1.1'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'androidx.room:room-runtime:2.4.2'
+    annotationProcessor 'androidx.room:room-compiler:2.4.2'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/sample-app/src/androidTest/java/com/sample/ExampleInstrumentedTest.java
+++ b/sample-app/src/androidTest/java/com/sample/ExampleInstrumentedTest.java
@@ -20,8 +20,8 @@
 package com.sample;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/sample-app/src/main/AndroidManifest.xml
+++ b/sample-app/src/main/AndroidManifest.xml
@@ -29,7 +29,8 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/sample-app/src/main/java/com/sample/MainActivity.java
+++ b/sample-app/src/main/java/com/sample/MainActivity.java
@@ -24,7 +24,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.view.View;
 
 import com.sample.database.CarDBHelper;

--- a/sample-app/src/main/java/com/sample/database/room/AppDatabase.java
+++ b/sample-app/src/main/java/com/sample/database/room/AppDatabase.java
@@ -1,7 +1,7 @@
 package com.sample.database.room;
 
-import android.arch.persistence.room.Database;
-import android.arch.persistence.room.RoomDatabase;
+import androidx.room.Database;
+import androidx.room.RoomDatabase;
 
 /**
  * Created by anandgaurav on 12/02/18.

--- a/sample-app/src/main/java/com/sample/database/room/User.java
+++ b/sample-app/src/main/java/com/sample/database/room/User.java
@@ -1,7 +1,7 @@
 package com.sample.database.room;
 
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.PrimaryKey;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
 
 /**
  * Created by anandgaurav on 12/02/18.

--- a/sample-app/src/main/java/com/sample/database/room/UserDBHelper.java
+++ b/sample-app/src/main/java/com/sample/database/room/UserDBHelper.java
@@ -1,7 +1,7 @@
 package com.sample.database.room;
 
-import android.arch.persistence.db.SupportSQLiteDatabase;
-import android.arch.persistence.room.Room;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.room.Room;
 import android.content.Context;
 
 import java.util.List;

--- a/sample-app/src/main/java/com/sample/database/room/UserDao.java
+++ b/sample-app/src/main/java/com/sample/database/room/UserDao.java
@@ -1,10 +1,10 @@
 package com.sample.database.room;
 
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Delete;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.OnConflictStrategy;
-import android.arch.persistence.room.Query;
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
 
 import java.util.List;
 

--- a/sample-app/src/main/java/com/sample/utils/Utils.java
+++ b/sample-app/src/main/java/com/sample/utils/Utils.java
@@ -19,7 +19,7 @@
 
 package com.sample.utils;
 
-import android.arch.persistence.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.SupportSQLiteDatabase;
 import android.content.Context;
 import android.util.Pair;
 import android.widget.Toast;


### PR DESCRIPTION
Upgrading to use AndroidX libraries instead of the older support libs and should allow Jetifier to be disabled. This addresses #183, supersedes #173 